### PR TITLE
Update getsummary

### DIFF
--- a/scripts/getsummary
+++ b/scripts/getsummary
@@ -327,7 +327,7 @@ foreach $file (@ARGV) {
 			    	last if /^\s*$/ || /^Memory/;
 			}
 		}
-		if (/size=16/) {
+		if (/size=16k/) {
 			while (<FD>) {
 				if (/^2 /) {
 					@_ = split; push(@lat_ctx16_2, $_[1]);


### PR DESCRIPTION
When the getsummary file is not updated, some values of our test report will be lost. After the update, this problem has been solved.
As shown below, this is the test report before updating the getsummary  file. After updating the file, you will get a complete test report without missing values.
 L M B E N C H  3 . 0   S U M M A R Y
                 ------------------------------------
		 (Alpha software, do not distribute)

Basic system parameters
------------------------------------------------------------------------------
Host                 OS Description              Mhz  tlb  cache  mem   scal
                                                     pages line   par   load
                                                           bytes  
--------- ------------- ----------------------- ---- ----- ----- ------ ----
loongson- Linux 4.19.90      mips64el-linux-gnu 1699          64   10.1    1

Processor, Processes - times in microseconds - smaller is better
------------------------------------------------------------------------------
Host                 OS  Mhz null null      open slct sig  sig  fork exec sh  
                             call  I/O stat clos TCP  inst hndl proc proc proc
--------- ------------- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
loongson- Linux 4.19.90 1699                                                  

Basic integer operations - times in nanoseconds - smaller is better
-------------------------------------------------------------------
Host                 OS  intgr intgr  intgr  intgr  intgr  
                          bit   add    mul    div    mod   
--------- ------------- ------ ------ ------ ------ ------ 
loongson- Linux 4.19.90                                   

Basic uint64 operations - times in nanoseconds - smaller is better
------------------------------------------------------------------
Host                 OS int64  int64  int64  int64  int64  
                         bit    add    mul    div    mod   
--------- ------------- ------ ------ ------ ------ ------ 
loongson- Linux 4.19.90                                   

Basic float operations - times in nanoseconds - smaller is better
-----------------------------------------------------------------
Host                 OS  float  float  float  float
                         add    mul    div    bogo
--------- ------------- ------ ------ ------ ------ 
loongson- Linux 4.19.90                            

Basic double operations - times in nanoseconds - smaller is better
------------------------------------------------------------------
Host                 OS  double double double double
                         add    mul    div    bogo
--------- ------------- ------  ------ ------ ------ 
loongson- Linux 4.19.90                            

Context switching - times in microseconds - smaller is better
-------------------------------------------------------------------------
Host                 OS  2p/0K 2p/16K 2p/64K 8p/16K 8p/64K 16p/16K 16p/64K
                         ctxsw  ctxsw  ctxsw ctxsw  ctxsw   ctxsw   ctxsw
--------- ------------- ------ ------ ------ ------ ------ ------- -------
loongson- Linux 4.19.90 3.7700 3.7600 3.8400 3.3300 4.0700 3.28000 3.83000